### PR TITLE
Add carousel and lightbox

### DIFF
--- a/app/data/projects.ts
+++ b/app/data/projects.ts
@@ -11,6 +11,7 @@ export interface Project {
   tools?: string[]
   technologies: string[]      // ← lo añado aquí
   image: string
+  images?: string[]
 }
 
 export const projects: Record<string, Project> = {
@@ -27,6 +28,7 @@ export const projects: Record<string, Project> = {
     tools: ["Generación de imágenes con IA", "AutoCAD"],
     technologies: ["Sonido", "Instalación", "Arte Digital"], // ← aquí
     image: "/projects/fallen-equinox/imagen1.png",
+    images: ["/projects/fallen-equinox/imagen1.png"],
   },
   "sonidos-de-origen": {
     id: "sonidos-de-origen",
@@ -41,6 +43,7 @@ export const projects: Record<string, Project> = {
     tools: [],
     technologies: ["Audio", "Cultura", "Instalación"], // ← aquí
     image: "/projects/sonidos-de-origen/imagen1.png",
+    images: ["/projects/sonidos-de-origen/imagen1.png"],
   },
   "ecos-de-la-tierra": {
     id: "ecos-de-la-tierra",
@@ -52,6 +55,7 @@ export const projects: Record<string, Project> = {
     tools: ["Touchdesigner"],
     technologies: ["Sensores", "Ecología", "Sonido"], // ← aquí
     image: "/projects/ecos-de-la-tierra/imagen1.png",
+    images: ["/projects/ecos-de-la-tierra/imagen1.png"],
   },
   // …añade el resto igual, incluyendo siempre `technologies: [...]`…
 }

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,7 +1,15 @@
+"use client"
+
 import { notFound } from "next/navigation"
 import Image from "next/image"
 import Link from "next/link"
 import { ArrowLeft } from "lucide-react"
+import { useState } from "react"
+import Slider from "react-slick"
+import "slick-carousel/slick/slick.css"
+import "slick-carousel/slick/slick-theme.css"
+import Lightbox from "yet-another-react-lightbox"
+import "yet-another-react-lightbox/styles.css"
 import { projects } from "@/app/data/projects"
 
 export async function generateStaticParams() {
@@ -16,6 +24,9 @@ export default function ProjectPage({
   const project = projects[params.id]
   if (!project) return notFound()
 
+  const images = project.images ?? [project.image]
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
+
   return (
     <div className="space-y-8">
       <Link
@@ -25,14 +36,38 @@ export default function ProjectPage({
         <ArrowLeft size={16} /> Volver a proyectos
       </Link>
 
-      <div className="relative h-80 rounded overflow-hidden">
-        <Image
-          src={project.image}
-          alt={project.title}
-          fill
-          className="object-cover"
-        />
-      </div>
+      {images.length > 0 && (
+        <Slider
+          dots
+          infinite
+          slidesToShow={1}
+          slidesToScroll={1}
+          className="rounded-md overflow-hidden"
+        >
+          {images.map((src, idx) => (
+            <div
+              key={idx}
+              className="relative h-80 cursor-pointer"
+              onClick={() => setLightboxIndex(idx)}
+            >
+              <Image
+                src={src}
+                alt={`${project.title} imagen ${idx + 1}`}
+                fill
+                className="object-cover"
+              />
+            </div>
+          ))}
+        </Slider>
+      )}
+
+      <Lightbox
+        open={lightboxIndex !== null}
+        index={lightboxIndex ?? 0}
+        close={() => setLightboxIndex(null)}
+        slides={images.map((src) => ({ src }))}
+        carousel={{ finite: false }}
+      />
 
       <div className="prose prose-invert">
         <h1>{project.title}</h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,10 @@
         "next": "15.2.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "react-slick": "^0.30.0",
+        "slick-carousel": "^1.8.1",
+        "yet-another-react-lightbox": "^2.17.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "next": "15.2.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "react-slick": "^0.30.0",
+    "slick-carousel": "^1.8.1",
+    "yet-another-react-lightbox": "^2.17.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## Summary
- add slick carousel and lightbox dependencies
- implement image carousel with lightbox modal on project page
- extend project data with images array for the carousel

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685147cb0a84832f8d1e5a8ac139a2a9